### PR TITLE
[DIFF] Support generating inline comments, and submitting them.

### DIFF
--- a/py/diffget.sh
+++ b/py/diffget.sh
@@ -1,0 +1,19 @@
+host=$1
+diffid=$2
+url="${host}/D${diffid}"
+cookie=$(cat ~/.config/phabrik/cookie.txt)
+
+curl ${url} \
+  -H 'Connection: keep-alive' \
+  -H 'Cache-Control: max-age=0' \
+  -H 'Upgrade-Insecure-Requests: 1' \
+  -H 'User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.96 Safari/537.36' \
+  -H 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9' \
+  -H 'Sec-Fetch-Site: none' \
+  -H 'Sec-Fetch-Mode: navigate' \
+  -H 'Sec-Fetch-User: ?1' \
+  -H 'Sec-Fetch-Dest: document' \
+  -H 'Accept-Language: en-GB,en-US;q=0.9,en;q=0.8' \
+  -H "Cookie: ${cookie}" \
+  --compressed 2> /dev/null |  xmllint --format --html - 2> /dev/null | grep "<input type" | grep -m 1 csrf
+

--- a/py/phab.py
+++ b/py/phab.py
@@ -8,7 +8,7 @@ import backend
 
 spath = pathlib.Path(__file__).parent.absolute()
 
-utils.__init__()
+utils.__init__(spath)
 backend = backend.Backend(str(spath))
 
 parser = argparse.ArgumentParser()
@@ -66,6 +66,7 @@ def create(args):
     backend.create(args.title)
 
 @subcommand([argument('diff'),
+             argument('--comment', action="store_true"),
              argument('--context', dest="context"),
              argument('--plan-changes', action="store_true"),
              argument('--request-review', action="store_true"),
@@ -99,6 +100,9 @@ def diff(args):
         return backend.diff_commandeer(args.diff)
     if(args.resign):
         return backend.diff_resign(args.diff)
+
+    if(args.comment):
+        return backend.diff_comment(args.diff, args.context)
 
     return backend.rawdiff(args.diff, args.context)
 

--- a/py/submit.sh
+++ b/py/submit.sh
@@ -1,0 +1,24 @@
+host=$1
+diffid=$2
+token=$3
+
+cookie=$(cat ~/.config/phabrik/cookie.txt)
+
+url="${host}/differential/revision/edit/${diffid}/comment/"
+
+curl ${url} \
+  -H 'Connection: keep-alive' \
+  -H "X-Phabricator-Csrf: ${token}" \
+  -H 'User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.96 Safari/537.36' \
+  -H "X-Phabricator-Via: /D${diffid}" \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  -H 'Accept: */*' \
+  -H "Origin: ${host}" \
+  -H 'Sec-Fetch-Site: same-origin' \
+  -H 'Sec-Fetch-Mode: cors' \
+  -H 'Sec-Fetch-Dest: empty' \
+  -H 'Accept-Language: en-GB,en-US;q=0.9,en;q=0.8' \
+  -H "Cookie: ${cookie}" \
+  --data-raw '__form__=1' \
+  --compressed
+


### PR DESCRIPTION
Unfortunately you cannot submit in-line comments using the conduit api.
To we use the API to prepare all the in-line comments...

At this point they would appear as unsubmitted in the web-interface.

We then use some curl foo to submit them, which uses the session cookie
stored in ~/.config/phabrik/cookie.txt